### PR TITLE
GitHub Actions: Deprecating save-state and set-output commands

### DIFF
--- a/get-changes.sh
+++ b/get-changes.sh
@@ -33,4 +33,4 @@ if [ ${#log} -gt 0 ]; then
 
 fi
 
-echo "::set-output name=log::$log"
+echo "log=$log" >> $GITHUB_OUTPUT

--- a/get-last-tag.sh
+++ b/get-last-tag.sh
@@ -2,4 +2,4 @@
 
 tag="$(git describe --tags --abbrev=0 @^ 2> /dev/null)"
 
-echo "::set-output name=last-tag::$tag"
+echo "last-tag=$tag" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The `set-output` command is deprecated and will be disabled soon.

For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/